### PR TITLE
Update package.json for Node 18+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "webpack-cli": "^6.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3000 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
     "@fortawesome/free-regular-svg-icons": "^5.9.0",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "bootstrap": "^4.3.1",
-    "gh-pages": "^2.1.1",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-scripts": "3.0.1"
+    "bootstrap": "^4.6.2",
+    "gh-pages": "^2.2.0",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
+    "react-icons": "^4.12.0",
+    "react-scripts": "^5.0.1",
+    "webpack": "^5.103.0",
+    "webpack-cli": "^6.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
I needed to update my NodeJS
Since NodeJS 17 (then NodeJS 18 for LTS), OpenSSL was updated and one of the cryptographic algorithm used in older versions stopped being supported leading to the error "ERR_OSSL_EVP_UNSUPPORTED", preventing this project from running using newer Node versions.
This is my answer to this deprecation.

I also added the PORT=XXXX variable to npm start for convenience and ease of use.